### PR TITLE
[ fix ] community cs

### DIFF
--- a/src/component/LikeButton.tsx
+++ b/src/component/LikeButton.tsx
@@ -85,7 +85,7 @@ export default function LikeButton({
 
       // 본인 작성글/답글 금지 처리 (ownerId가 전달된 경우에만 검사)
       if (ownerId && ownerId === uid) {
-        toast('warn', '본인 게시글에는 좋아요를 누를 수 없습니다.');
+        toast('warn', '본인 작성글 좋아요를 누를 수 없습니다.');
         setBusy(false);
         return;
       }

--- a/src/component/TagInput.tsx
+++ b/src/component/TagInput.tsx
@@ -22,10 +22,15 @@ export default function TagInput({
   max = 5,
   placeholder = '추가 태그 입력 (최대 5개)',
 }: Props) {
+  const composingRef = React.useRef(false);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // IME(한글 등) 조합 중 Enter 무시 (Mac 중복 입력 방지)
+    if (composingRef.current || (e.nativeEvent as any)?.isComposing) return;
+
     if (e.key === 'Enter') {
       e.preventDefault();
-      onAdd();
+      if (tags.length < max) onAdd();
     }
   };
 
@@ -52,6 +57,8 @@ export default function TagInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
+          onCompositionStart={() => (composingRef.current = true)}
+          onCompositionEnd={() => (composingRef.current = false)}
           aria-label="태그 입력"
         />
 
@@ -59,7 +66,7 @@ export default function TagInput({
           size="md"
           type="button"
           borderType="outline"
-          onClick={() => onAdd()}
+          onClick={() => tags.length < max && onAdd()}
           disabled={tags.length >= max}
         >
           추가

--- a/src/component/TagInput.tsx
+++ b/src/component/TagInput.tsx
@@ -66,7 +66,10 @@ export default function TagInput({
           size="md"
           type="button"
           borderType="outline"
-          onClick={() => tags.length < max && onAdd()}
+          onClick={(e) => {
+            (e as React.MouseEvent).preventDefault();
+            if (tags.length < max) onAdd();
+          }}
           disabled={tags.length >= max}
         >
           추가

--- a/src/hook/useEditPost.ts
+++ b/src/hook/useEditPost.ts
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 import useToast from '@/hook/useToast';
 import supabase from '@/supabase/supabase';
 import { useCommunityStore } from '@/pages/community/write/store/useCommunityStore';
+import { uploadFilesToBucket } from '@/supabase/community/uploadImages';
 
 export default function useEditPost() {
   const location = useLocation() as any;
@@ -46,15 +47,50 @@ export default function useEditPost() {
     if (!isEditMode || !editPost) return;
     try {
       const store = useCommunityStore.getState();
+
+      // 업로드 처리: 이미 파일 객체(files)와 imageUrls/imageNames를 전달해
+      // blob(URL) -> publicUrl 치환 및 finalImageUrls 반환 받음
+      const files: File[] = store.imageFiles ?? [];
+      const storeImageUrls = store.imageUrls ?? [];
+      const storeImageNames = store.imageNames ?? [];
+      const BUCKET = (import.meta.env.VITE_SUPABASE_STORAGE_BUCKET as string) ?? 'post_images';
+
+      let mapping: Record<string, string> = {};
+      // store.imageUrls는 (string | null)[] 일 수 있으므로 먼저 같은 타입으로 둠
+      let finalImageUrls: (string | null)[] = storeImageUrls.slice();
+      let newBody = store.body || '';
+
+      if (files.length > 0 || (storeImageUrls || []).some((u) => typeof u === 'string' && (u as string).startsWith('blob:'))) {
+        const res = await uploadFilesToBucket(files, BUCKET, storeImageUrls, storeImageNames);
+        mapping = res.mapping || {};
+        // res.finalImageUrls는 string[]이므로 (string|null)[] 변수에 안전하게 할당
+        finalImageUrls = res.finalImageUrls || [];
+        // 본문 내부 blob 치환
+        for (const [blobUrl, pubUrl] of Object.entries(mapping)) {
+          if (blobUrl && pubUrl) newBody = newBody.split(blobUrl).join(pubUrl);
+        }
+      } else {
+        // 파일 변경이 없다면 그대로 (단 null/undefined 제거)
+        finalImageUrls = (storeImageUrls || []).filter((u): u is string => Boolean(u));
+      }
+
       const payload: any = {
         title: (store.title || 'untitled').trim(),
-        content: store.body || '',
+        content: newBody,
         post_category: store.category || 'free',
         hashtag_list: store.tags && store.tags.length > 0 ? store.tags : null,
       };
-      if (Array.isArray(store.imageUrls) && store.imageUrls.length > 0) {
-        payload.image_url = store.imageUrls;
-        payload.thumbnail_image = store.imageUrls[store.primaryIdx ?? 0] ?? store.imageUrls[0];
+      // DB에 넣기 전 null/빈 값 제거하여 string[]로 정리
+      const safeFinalUrls: string[] = (finalImageUrls || []).filter(
+        (u): u is string => typeof u === 'string' && u.trim() !== ''
+      );
+      if (safeFinalUrls && safeFinalUrls.length > 0) {
+        payload.image_url = safeFinalUrls;
+        payload.thumbnail_image = safeFinalUrls[store.primaryIdx ?? 0] ?? safeFinalUrls[0];
+      } else {
+        // 이미지가 완전히 제거된 경우 필드 제거(또는 null 설정으로 처리)
+        payload.image_url = null;
+        payload.thumbnail_image = null;
       }
 
       const { error } = await supabase
@@ -64,12 +100,13 @@ export default function useEditPost() {
         .select()
         .single();
       if (error) {
-        console.error('[useEditPost] update error', error);
+        console.error('[useEditPost] update error', error, { payload });
         toast('error', '수정에 실패했습니다.');
         return;
       }
       toast('success', '수정되었습니다.');
-      navigate(`/community/detail/${editPost.post_id}`);
+      // 상세로 이동하여 최신 데이터 조회
+      navigate(`/community/detail/${editPost.post_id}`, { replace: true });
     } catch (e) {
       console.error('[useEditPost] handleSaveEdit caught', e);
       toast('error', '수정 중 오류가 발생했습니다.');

--- a/src/hook/useTags.ts
+++ b/src/hook/useTags.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import supabase from '@/supabase/supabase';
+import { useNavigate } from 'react-router';
 import { fetchPopularPosts, fetchGlobalTopTags } from '@/supabase/community/communityService';
 import type { PostWithProfile } from '@/supabase/community/communityService';
 
@@ -9,6 +9,7 @@ import type { PostWithProfile } from '@/supabase/community/communityService';
 export function usePopularTags(popularLimit = 5, tagLimit = 5) {
   const [popular, setPopular] = useState<PostWithProfile[] | null>(null);
   const [globalTags, setGlobalTags] = useState<string[] | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     let mounted = true;
@@ -42,30 +43,10 @@ export function usePopularTags(popularLimit = 5, tagLimit = 5) {
     };
   }, [popularLimit, tagLimit]);
 
-  const handleTagClick = async (tag: string) => {
+  const handleTagClick = (tag: string) => {
     const plain = tag.replace(/^#/, '').trim();
     if (!plain) return;
-    try {
-      const { data, error } = await supabase
-        .from('posts')
-        .select('post_id')
-        .contains('hashtag_list', [plain])
-        .order('like_count', { ascending: false })
-        .order('created_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (error) {
-        console.error('[handleTagClick] supabase error', error);
-      }
-      if (data && (data as any).post_id) {
-        window.location.href = `/community/detail/${(data as any).post_id}`;
-        return;
-      }
-    } catch (e) {
-      console.error('[handleTagClick] caught', e);
-    }
-    window.location.href = `/community/tag/${encodeURIComponent(plain)}`;
+    navigate(`/community?tag=${encodeURIComponent(plain)}`);
   };
 
   return { popular, globalTags, handleTagClick };

--- a/src/pages/community/Main/CommunityMain.tsx
+++ b/src/pages/community/Main/CommunityMain.tsx
@@ -6,8 +6,7 @@ import ScrollToTopButton from '@/component/community/ScrollToTopButton';
 import PopularLike from '@/pages/community/Main/PopularLike';
 import { usePosts } from '@/hook/usePosts';
 import { usePopularTags } from '@/hook/useTags';
-import { useLocation } from 'react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 function CommunityMain() {
   // 분리된 훅 사용
@@ -21,7 +20,6 @@ function CommunityMain() {
     const plain = String(tag).replace(/^#/, '').trim();
     if (!plain) return;
     setActiveTag(plain);
-    // fetchPosts는 "#tag" 포맷을 해시태그 검색 모드로 처리하도록 구현되어 있음
     fetchPosts(`#${plain}`, sortBy);
   };
 

--- a/src/pages/community/Main/CommunityMain.tsx
+++ b/src/pages/community/Main/CommunityMain.tsx
@@ -6,12 +6,30 @@ import ScrollToTopButton from '@/component/community/ScrollToTopButton';
 import PopularLike from '@/pages/community/Main/PopularLike';
 import { usePosts } from '@/hook/usePosts';
 import { usePopularTags } from '@/hook/useTags';
+import { useLocation } from 'react-router';
+import { useEffect, useState } from 'react';
 
 function CommunityMain() {
   // 분리된 훅 사용
   const { posts, search, setSearch, fetchPosts, placeholders, debounceRef, sortBy, setSortBy } =
     usePosts();
-  const { popular, globalTags, handleTagClick } = usePopularTags();
+  const { popular, globalTags } = usePopularTags();
+
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  const handleTagClickLocal = (tag: string) => {
+    const plain = String(tag).replace(/^#/, '').trim();
+    if (!plain) return;
+    setActiveTag(plain);
+    // fetchPosts는 "#tag" 포맷을 해시태그 검색 모드로 처리하도록 구현되어 있음
+    fetchPosts(`#${plain}`, sortBy);
+  };
+
+  const clearActiveTag = () => {
+    setActiveTag(null);
+    setSearch('');
+    fetchPosts(undefined, sortBy);
+  };
 
   return (
     <div className="min-h-full">
@@ -73,6 +91,7 @@ function CommunityMain() {
                     }}
                     className="w-full rounded-full border-2 border-gray-600 px-4 py-2 text-sm hover:border-primary-500 focus:border-primary-500 focus:outline-none"
                     placeholder="검색어를 입력하세요 (제목 또는 내용)"
+                    autoComplete="off"
                   />
                 </div>
 
@@ -80,7 +99,6 @@ function CommunityMain() {
                   <h4 className="font-semibold mb-2">인기글</h4>
                   <ul className="text-sm text-gray-600 space-y-2">
                     {popular === null ? (
-                      // 로딩 플레이스홀더
                       Array.from({ length: 3 }).map((_, i) => (
                         <li key={i} className="flex justify-between opacity-50">
                           <span>로딩 중...</span>
@@ -115,6 +133,15 @@ function CommunityMain() {
 
               <div className="bg-white rounded-lg p-4 shadow-sm">
                 <h4 className="font-semibold mb-2">인기 태그</h4>
+                {/* 태그 필터 활성화 표시/초기화 버튼 */}
+                {activeTag && (
+                  <div className="mb-3 text-sm">
+                    현재 태그 필터: <strong>#{activeTag}</strong>
+                    <button className="ml-3 text-xs text-gray-500" onClick={clearActiveTag}>
+                      필터 해제
+                    </button>
+                  </div>
+                )}
                 <div className="flex flex-wrap gap-2">
                   {globalTags === null ? (
                     Array.from({ length: 3 }).map((_, i) => (
@@ -125,16 +152,24 @@ function CommunityMain() {
                   ) : globalTags.length === 0 ? (
                     <div className="text-sm text-gray-500">태그가 없습니다.</div>
                   ) : (
-                    globalTags.map((t) => (
-                      <button
-                        key={t}
-                        type="button"
-                        className="flex items-center gap-2 px-3 py-1.5 rounded-full border border-primary-400 text-sm text-primary-400 bg-white shadow-sm cursor-pointer"
-                        onClick={() => handleTagClick(t)}
-                      >
-                        # {t}
-                      </button>
-                    ))
+                    globalTags.map((t) => {
+                      const plain = String(t).replace(/^#/, '').trim();
+                      const isActive = activeTag === plain;
+                      return (
+                        <button
+                          key={t}
+                          type="button"
+                          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm shadow-sm cursor-pointer ${
+                            isActive
+                              ? 'bg-primary-400 text-white border-transparent'
+                              : 'border border-primary-400 text-primary-400 bg-white'
+                          }`}
+                          onClick={() => handleTagClickLocal(String(t))}
+                        >
+                          # {plain}
+                        </button>
+                      );
+                    })
                   )}
                 </div>
               </div>

--- a/src/pages/community/detail/CommunityDetail.tsx
+++ b/src/pages/community/detail/CommunityDetail.tsx
@@ -48,7 +48,7 @@ function CommunityDetail() {
           setPost(postData as PostWithProfile | null);
         }
 
-        // 댓글 조회: 해당 post_id의 최상위 댓글만(대댓글은 PostComment 내부에서 처리)
+        // 댓글 조회
         const { data: replyData, error: replyError } = await supabase
           .from('reply')
           .select('*, profile(profile_id,nickname,profile_image_url)')
@@ -68,9 +68,18 @@ function CommunityDetail() {
       }
     };
 
+    // 즉시 호출
     fetchPostAndReplies();
+
+    // 뒤로/앞으로 이동(popstate) 시에도 재조회하도록 리스너 추가
+    const onPop = () => {
+      fetchPostAndReplies();
+    };
+    window.addEventListener('popstate', onPop);
+
     return () => {
       mounted = false;
+      window.removeEventListener('popstate', onPop);
     };
   }, [postId]);
 

--- a/src/pages/community/write/CommunityWrite.tsx
+++ b/src/pages/community/write/CommunityWrite.tsx
@@ -14,7 +14,12 @@ function CommunityWrite() {
           </p>
         </header>
 
-        <form className="grid grid-cols-12 gap-8">
+        <form
+          className="grid grid-cols-12 gap-8"
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
           <LeftContent onSave={isEditMode ? handleSaveEdit : undefined} />
           <RightPreview />
         </form>

--- a/src/pages/community/write/LeftContent.tsx
+++ b/src/pages/community/write/LeftContent.tsx
@@ -42,17 +42,15 @@ function LeftContent({ onSave }: { onSave?: () => Promise<void> | void }) {
     setTagInput('');
     clearImages();              // 이미지/프리뷰/대표 초기화
 
-    // 2) 이동(뒤로가기 → 폴백)
-    if (window.history.length > 1) {
-      navigate(-1);
-      return;
-    }
+    // 2) 이동(이전으로 단순 돌아가기 대신 명시적 라우트로 이동)
     const postId = location.state?.post?.post_id;
     if (location.state?.mode === 'edit' && postId) {
-      navigate(`/community/detail/${postId}`);
-    } else {
-      navigate('/community');
+      // 편집 취소: 상세 페이지로 강제 이동 -> 상세 컴포넌트가 재조회되도록 함
+      navigate(`/community/detail/${postId}`, { replace: true });
+      return;
     }
+    // 일반 취소: 리스트로 이동
+    navigate('/community', { replace: true });
   };
 
   return (

--- a/src/supabase/community/uploadImages.ts
+++ b/src/supabase/community/uploadImages.ts
@@ -12,10 +12,25 @@ function makeFileName(file: File) {
 }
 
 /**
- * 여러 파일을 사용자 폴더로 직접 업로드하고 publicUrl 반환
+ * files: 업로드할 File[] (새로 추가된 파일 객체)
+ * imageUrls: 현재 스토어의 imageUrls 배열 (publicUrl 또는 blob:... 혼합)
+ * imageNames: 현재 스토어의 imageNames 배열 (파일명 또는 기존 public 파일명)
+ *
+ * 반환:
+ * { publicUrls, paths, mapping, finalImageUrls }
+ * - mapping: { [blobUrl]: publicUrl }
+ * - finalImageUrls: original imageUrls에서 blob 항목을 mapping으로 치환한 최종 배열 (순서 보존)
  */
-export async function uploadFilesToBucket(files: File[], bucket = 'post_images') {
-  if (!files || files.length === 0) return { publicUrls: [], paths: [] };
+export async function uploadFilesToBucket(
+  files: File[],
+  bucket = 'post_images',
+  imageUrls: (string | null)[] = [],
+  imageNames: (string | null)[] = []
+) {
+  if (!files || files.length === 0) {
+    // 파일 없으면 이미지 배열 그대로 반환 (mapping 빈 객체)
+    return { publicUrls: [], paths: [], mapping: {}, finalImageUrls: imageUrls.slice() };
+  }
 
   const { data: userData } = await supabase.auth.getUser();
   const userId = (userData as any)?.user?.id;
@@ -24,25 +39,20 @@ export async function uploadFilesToBucket(files: File[], bucket = 'post_images')
   const publicUrls: string[] = [];
   const paths: string[] = [];
 
+  // 업로드 (전달된 File[] 먼저 업로드)
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     const filename = makeFileName(file);
     const path = `${userId}/posts/${filename}`;
-
     try {
       const { error } = await supabase.storage.from(bucket).upload(path, file, {
         cacheControl: '3600',
         upsert: false,
         contentType: file.type,
       });
-
-      if (error) {
-        throw new Error(error.message || JSON.stringify(error));
-      }
-
+      if (error) throw new Error(error.message || JSON.stringify(error));
       const { data: urlData } = await supabase.storage.from(bucket).getPublicUrl(path);
       const publicUrl = (urlData as any)?.publicUrl ?? (urlData as any)?.public_url ?? '';
-
       publicUrls.push(publicUrl);
       paths.push(path);
     } catch (err: any) {
@@ -56,5 +66,99 @@ export async function uploadFilesToBucket(files: File[], bucket = 'post_images')
     }
   }
 
-  return { publicUrls, paths };
+  // 매핑 생성: files[] 순서 -> imageNames/imageUrls 위치 매칭
+  const mapping: Record<string, string> = {};
+  const names = (imageNames || []).slice();
+  const urls = (imageUrls || []).slice();
+
+  for (let i = 0; i < publicUrls.length; i++) {
+    const pub = publicUrls[i];
+    const file = files[i];
+
+    // 1) 같은 파일명(imageNames) 위치 찾기 (첫번째 일치)
+    let idx = -1;
+    if (file && names.length > 0) {
+      idx = names.findIndex((n) => n === file.name);
+    }
+
+    if (idx !== -1) {
+      const possible = urls[idx];
+      if (typeof possible === 'string' && possible.startsWith('blob:')) {
+        mapping[possible] = pub;
+        names[idx] = null;
+        urls[idx] = null;
+        continue;
+      }
+    }
+
+    // 2) fallback: 남아있는 첫 blob 위치에 매핑
+    const blobIndex = urls.findIndex((u) => typeof u === 'string' && (u as string).startsWith('blob:'));
+    if (blobIndex !== -1) {
+      const blobUrl = urls[blobIndex] as string;
+      mapping[blobUrl] = pub;
+      names[blobIndex] = null;
+      urls[blobIndex] = null;
+      continue;
+    }
+
+    // 3) 만약 더 이상 blob이 없으면 (기존 public들 사이에 새 추가된 경우)
+    // 새로 추가된 파일은 맨 끝에 붙이는 정책으로 publicUrls 배열을 따로 보존
+  }
+
+  // --- 추가: 아직 mapping에 없는 blob URL(파일 객체 없이 생긴 blob: URL) 업로드 처리 ---
+  const remainingUrls = (imageUrls || []).slice();
+  const unmappedBlobs = remainingUrls.filter(
+    (u) => typeof u === 'string' && (u as string).startsWith('blob:') && !(u in mapping)
+  ) as string[];
+
+  for (const blobUrl of unmappedBlobs) {
+    try {
+      // fetch blob from blob: URL and convert to File
+      const resp = await fetch(blobUrl);
+      const blob = await resp.blob();
+      const mime = blob.type || 'image/jpeg';
+      const ext = (mime.split('/')[1] || 'jpg').split('+')[0];
+      const filename = makeFileName(new File([blob], `pasted.${ext}`, { type: mime }));
+      const path = `${userId}/posts/${filename}`;
+      const file = new File([blob], filename, { type: mime });
+
+      const { error } = await supabase.storage.from(bucket).upload(path, file, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType: file.type,
+      });
+      if (error) {
+        console.error('[uploadFilesToBucket] upload pasted blob error', { blobUrl, error });
+        continue;
+      }
+      const { data: urlData } = await supabase.storage.from(bucket).getPublicUrl(path);
+      const publicUrl = (urlData as any)?.publicUrl ?? (urlData as any)?.public_url ?? '';
+      // mapping 및 결과에 추가
+      mapping[blobUrl] = publicUrl;
+      publicUrls.push(publicUrl);
+      paths.push(path);
+      // revoke local blobURL if possible
+      try {
+        if (typeof URL !== 'undefined' && URL.revokeObjectURL) URL.revokeObjectURL(blobUrl);
+      } catch {}
+    } catch (e) {
+      console.error('[uploadFilesToBucket] fetch pasted blob error', { blobUrl, err: e });
+      continue;
+    }
+  }
+
+  // finalImageUrls: 원본 imageUrls 순서 보존하며 blob 치환
+  const finalImageUrls = (imageUrls || []).map((u) => {
+    if (typeof u === 'string' && u.startsWith('blob:')) {
+      return mapping[u] ?? null;
+    }
+    return u;
+  });
+
+  // 이후에도 uploaded files 중 매핑되지 않은 publicUrls(추가된 파일) 있으면 append
+  const mappedPubSet = new Set(Object.values(mapping));
+  const remainingPubs = publicUrls.filter((p) => !mappedPubSet.has(p));
+  const final = finalImageUrls.concat(remainingPubs).filter(Boolean) as string[];
+
+  return { publicUrls, paths, mapping, finalImageUrls: final };
 }


### PR DESCRIPTION
## 📌 과제 설명
mac IME에서 태그 중복 입력 방지
글 수정 시 이미지(blob) 깨짐 방지(블롭 → 스토리지 업로드 및 본문 치환)
인기 태그 클릭 시 조회 동작으로 변경

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[ fix ] mac 태그 두 개씩 등록 되는 문제
mac(IME) 환경에서 태그 입력 후 Enter 시 태그가 두 번 등록되는 문제를 해결
- [ ] mac/IME 환경에서 Enter로 태그 추가 시 태그가 한 번만 추가되는지 확인.

[ fix ] 이미지 수정 시 이미지 깨짐 현상
글 수정(edit) 시 새로 추가된 이미지(파일 선택 또는 에디터에 붙여넣은 blob)가 저장 후에도 blob URL로 남아 깨지는 문제 해결
- [ ] 수정 : 기존 글 수정→ 새 이미지 추가 → 취소 or 저장 → 이미지 깨짐현상 없음

[ fix ] 인기 태그 인기 태그에서 태그 클릭 시 조회로 수정
인기(추천) 태그 클릭 시 단순 highlight가 아니라 해당 태그로 목록을 조회/필터
- [ ] 태그 클릭 후 검색/필터 해제 동작되는 지 확인
